### PR TITLE
chore: remove crate visibility from Account for accessibility

### DIFF
--- a/ethereum/circuits/lib/src/account.nr
+++ b/ethereum/circuits/lib/src/account.nr
@@ -13,8 +13,8 @@ pub(crate) global MAX_ACCOUNT_STATE_LEN: u32 = 110; // Values taken from account
 pub(crate) global MAX_ACCOUNT_LEAF_LEN: u32 = 148;
 
 pub struct AccountWithinBlock {
-    pub(crate) account: Account,
-    pub(crate) block_hash: Bytes32,
+    pub account: Account,
+    pub block_hash: Bytes32,
 }
 
 impl Eq for AccountWithinBlock {

--- a/ethereum/circuits/lib/src/account_with_storage.nr
+++ b/ethereum/circuits/lib/src/account_with_storage.nr
@@ -20,10 +20,10 @@ pub(crate) global MAX_STORAGE_VALUE_LEN: u32 = 32; // Values taken from storageP
 pub(crate) global MAX_STORAGE_LEAF_LEN: u32 = 69;
 
 pub struct Account {
-    pub(crate) nonce: u64,
-    pub(crate) balance: Field,
-    pub(crate) storage_root: Bytes32,
-    pub(crate) code_hash: Bytes32,
+    pub nonce: u64,
+    pub balance: Field,
+    pub storage_root: Bytes32,
+    pub code_hash: Bytes32,
 }
 
 impl Eq for Account {


### PR DESCRIPTION
This pull request makes small but important changes to the visibility of struct fields in the `ethereum/circuits/lib/src/account.nr` and `ethereum/circuits/lib/src/account_with_storage.nr` files. The changes increase the accessibility of fields in the `AccountWithinBlock` and `Account` structs by making them public, which allows other modules to access these fields directly.

Visibility updates:

* Made all fields of the `AccountWithinBlock` struct public in `account.nr` to allow external access.
* Made all fields of the `Account` struct public in `account_with_storage.nr` to allow external access.

Also,
- resolves #28

Do let me know if you feel other things should also be made more accessible for general use cases. This was for mine, maybe someone building something else needs other things.

cc: @TomAFrench 